### PR TITLE
Bad fix for the click - stopping propogation from bubbling to parent …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,10 +39,13 @@ class App extends Component {
   }
 
   handleOpenModal () {
+    console.log('in open modal button click');
     this.setState({showModal: true});
   }
 
-  handleCloseModal () {
+  handleCloseModal (e) {
+    console.log('in CLOSE modal button click');
+    e.stopPropagation(); // blocks click from bubbling to parent button which is in parent
     this.setState({showModal: false});
   }
   


### PR DESCRIPTION
…button.


This is a good way to learn `stopPropagation`. Comment out the `e.stopPropagation()` and see the console logs.

The real fix should be to not nest other funciton triggering stuff in a button. Button content should strictly be looks for that button.